### PR TITLE
add backwards_ros and allow different cmake build types

### DIFF
--- a/teb_local_planner/CMakeLists.txt
+++ b/teb_local_planner/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 project(teb_local_planner)
 
 # Set to Release in order to speed up the program significantly
-set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
+endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -35,6 +37,7 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(backward_ros REQUIRED)
 
 message(STATUS "System: ${CMAKE_SYSTEM}")
 ## System dependencies are found with CMake's conventions

--- a/teb_local_planner/package.xml
+++ b/teb_local_planner/package.xml
@@ -38,6 +38,9 @@
   <depend>teb_msgs</depend>
   <depend>tf2</depend>
   <depend>visualization_msgs</depend>
+  
+  <depend>backward_ros</depend>
+  
   <exec_depend>nav2_bringup</exec_depend>
   
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
adds stacktraces, see
![stacktrace_teb_costmap](https://user-images.githubusercontent.com/17068999/102977476-5482aa80-4503-11eb-8d72-021345c88ad6.png)
