### PR TITLE
WMO-56756 Teb goal checker

### DIFF
--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -137,7 +137,21 @@ public:
   geometry_msgs::msg::TwistStamped computeVelocityCommands(
     const geometry_msgs::msg::PoseStamped &pose,
     const geometry_msgs::msg::Twist &velocity);
-  
+
+  bool isGoalReached(
+    const geometry_msgs::msg::PoseStamped & pose,
+    const geometry_msgs::msg::Twist & velocity) ;
+
+  /**
+    * @brief  Check if the goal pose has been achieved
+    *
+    * The actual check is performed in computeVelocityCommands().
+    * Only the status flag is checked here.
+    * @return True if achieved, false otherwise
+    */
+  bool isGoalReached();
+
+
     
   /** @name Public utility functions/methods */
   //@{
@@ -386,6 +400,7 @@ private:
   PoseSE2 robot_pose_; //!< Store current robot pose
   PoseSE2 robot_goal_; //!< Store current robot goal
   geometry_msgs::msg::Twist robot_vel_; //!< Store current robot translational and angular velocity (vx, vy, omega)
+  bool goal_reached_; //!< store whether the goal is reached or not
   rclcpp::Time time_last_infeasible_plan_; //!< Store at which time stamp the last infeasible plan was detected
   int no_infeasible_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
   rclcpp::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -68,7 +68,7 @@ namespace teb_local_planner
 TebLocalPlannerROS::TebLocalPlannerROS() 
     : nh_(nullptr), costmap_ros_(nullptr), tf_(nullptr), cfg_(new TebConfig()), costmap_model_(nullptr), intra_proc_node_(nullptr),
                                            costmap_converter_loader_("costmap_converter", "costmap_converter::BaseCostmapToPolygons"),
-                                           custom_via_points_active_(false), no_infeasible_plans_(0),
+                                           custom_via_points_active_(false), goal_reached_(false), no_infeasible_plans_(0),
                                            last_preferred_rotdir_(RotType::none), initialized_(false)
 {
 }
@@ -250,6 +250,9 @@ void TebLocalPlannerROS::setPlan(const nav_msgs::msg::Path & orig_global_plan)
   // we do not clear the local planner here, since setPlan is called frequently whenever the global planner updates the plan.
   // the local planner checks whether it is required to reinitialize the trajectory or not within each velocity computation step.  
 
+  // reset goal_reached_ flag
+  goal_reached_ = false;
+
   return;
 }
 
@@ -272,7 +275,8 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   cmd_vel.twist.linear.x = 0;
   cmd_vel.twist.linear.y = 0;
   cmd_vel.twist.angular.z = 0;
-  
+  goal_reached_ = false;
+
   // Get robot pose
   robot_pose_ = PoseSE2(pose.pose);
   geometry_msgs::msg::PoseStamped robot_pose;
@@ -307,7 +311,18 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   nav_2d_utils::transformPose(tf_, robot_pose.header.frame_id, global_plan_.back(), global_goal, transform_tolerance);
   //tf::poseStampedMsgToTF(global_plan_.back(), global_goal);
   //global_goal.setData( tf_plan_to_global * global_goal );
-  
+  double dx = global_goal.pose.position.x - robot_pose_.x();
+  double dy = global_goal.pose.position.y - robot_pose_.y();
+  double delta_orient = g2o::normalize_theta( tf2::getYaw(global_goal.pose.orientation) - robot_pose_.theta() );
+  if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_->goal_tolerance.xy_goal_tolerance
+    && fabs(delta_orient) < cfg_->goal_tolerance.yaw_goal_tolerance
+    && (!cfg_->goal_tolerance.complete_global_plan || via_points_.size() == 0))
+  {
+    goal_reached_ = true;
+    return cmd_vel;
+  }
+
+
   // check if we should enter any backup mode and apply settings
   configureBackupModes(transformed_plan, goal_idx);
   
@@ -472,6 +487,23 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   visualization_->publishGlobalPlan(global_plan_);
   
   return cmd_vel;
+}
+
+bool TebLocalPlannerROS::isGoalReached(
+  const geometry_msgs::msg::PoseStamped &,
+  const geometry_msgs::msg::Twist &) {
+  return isGoalReached();
+}
+
+bool TebLocalPlannerROS::isGoalReached()
+{
+  if (goal_reached_)
+  {
+    RCLCPP_INFO(nh_->get_logger(), "GOAL Reached!");
+    planner_->clearPlanner();
+    return true;
+  }
+  return false;
 }
 
 void TebLocalPlannerROS::updateObstacleContainerWithCostmap()


### PR DESCRIPTION
the nav2 goal checker has a problem: It is defined for the controller_server.
We have multiple teb configurations but we can't adapt it for those configs. The old teb goal checker however, as it is part of teb, can be configured separately with teb.
So, let's bring it back. 
Config changes to nav2 will get another PR in that repo.