### PR TITLE
AGVFM-255 Navigation stops after coarse goal reaching

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -325,6 +325,9 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     && (!cfg_->goal_tolerance.complete_global_plan || via_points_.size() == 0))
   {
     goal_reached_ = true;
+    if (cfg_->goal_tolerance.free_goal_vel) {
+        cmd_vel.twist = last_cmd_;
+    }
     return cmd_vel;
   }
 


### PR DESCRIPTION
---

## Basic Info

| Info | Navigation stops after coarse goal reaching |
| ------ | ----------- |
| Ticket(s) this addresses   | https://lvserv01.logivations.com/browse/AGVFM-255 |
| Primary OS tested on | Ubuntu |
| Tested on AGV | yes |
| Robotic platform tested on | W2MO simulation |

---

## Description of contribution in a few bullet points

* if free_goal_vel set to true, do not publish stop command, instead return previous command
