### PR TITLE
task_agvfm_667_show_error_in_logs_if_no_obstacles_received

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -387,12 +387,14 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     // TODO: 5 seconds?
     if (seconds_diff > 5){
       RCLCPP_INFO(nh_->get_logger(), "Diff %f", seconds_diff);
+      RCLCPP_ERROR(nh_->get_logger(), "No new obstacles were received for the past 5 seconds");
       cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
       last_cmd_ = cmd_vel.twist;
       return cmd_vel;
     }
   }
   else{
+    RCLCPP_ERROR(nh_->get_logger(), "No obstacles were received");
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
     last_cmd_ = cmd_vel.twist;
     return cmd_vel;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Added an error when no obstacles were received |
| ------ | ----------- |
| Ticket(s) this addresses   | https://lvserv01.logivations.com/browse/AGVFM-667 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | W2MO 3D simulation |

---

## Description of contribution in a few bullet points

* An error in logs is now shown when no obstacles are received

---
