### PR TITLE
Amrfm 880 Split fill_grade obstacles from general obstacles

### DIFF
--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -66,7 +66,8 @@ public:
   
   std::string odom_topic; //!< Topic name of the odometry message, provided by the robot driver or simulator
   std::string custom_obst_topic; //!< Topic name of the custom obstacle message, provided by the robot driver or simulator
-  std::string custom_narrow_obst_topic; //!< Topic name of the custom obstacle message, provided by the robot driver or simulator
+  std::string custom_narrow_obst_topic; //!< Topic name of the custom narrow obstacles message,  obstacles are provided by the AdjustPalletGoal Action Server
+  std::string custom_fill_grade_obst_topic; //!< Topic name of the custom fill grade obstacles message, obstacles are provided by the camera server
   std::string map_frame; //!< Global planning frame
 
   //! Trajectory related parameters
@@ -245,6 +246,7 @@ public:
     odom_topic = "odom";
     custom_obst_topic = "obstacles";
     custom_narrow_obst_topic = "narrow_obstacles";
+    custom_fill_grade_obst_topic = "fill_grade_obstacles";
     map_frame = "odom";
 
     // Trajectory

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -67,7 +67,7 @@ public:
   std::string odom_topic; //!< Topic name of the odometry message, provided by the robot driver or simulator
   std::string custom_obst_topic; //!< Topic name of the custom obstacle message, provided by the robot driver or simulator
   std::string custom_narrow_obst_topic; //!< Topic name of the custom narrow obstacles message,  obstacles are provided by the AdjustPalletGoal Action Server
-  std::string custom_fill_grade_obst_topic; //!< Topic name of the custom fill grade obstacles message, obstacles are provided by the camera server
+  std::string custom_static_obst_topic; //!< Topic name of the custom fill grade obstacles message, obstacles are provided by the camera server
   std::string map_frame; //!< Global planning frame
 
   //! Trajectory related parameters
@@ -246,7 +246,7 @@ public:
     odom_topic = "odom";
     custom_obst_topic = "obstacles";
     custom_narrow_obst_topic = "narrow_obstacles";
-    custom_fill_grade_obst_topic = "fill_grade_obstacles";
+    custom_static_obst_topic = "static_obstacles";
     map_frame = "odom";
 
     // Trajectory

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -407,15 +407,15 @@ private:
   //std::shared_ptr< dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig> > dynamic_recfg_; //!< Dynamic reconfigure server to allow config modifications at runtime
   rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
   rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_narrow_obst_sub_; //!< Subscriber for custom narrow obstacles received via a ObstacleMsg.
-  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_fill_grade_obst_sub_; //!< Subscriber for custom fill grade obstacles received via a ObstacleMsg.
+  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_static_obst_sub_; //!< Subscriber for custom fill grade obstacles received via a ObstacleMsg.
   std::mutex custom_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   std::mutex custom_narrow_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
-  std::mutex custom_fill_grade_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
+  std::mutex custom_static_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   costmap_converter_msgs::msg::ObstacleArrayMsg custom_obstacle_msg_; //!< Copy of the most recent obstacle message
 
   costmap_converter_msgs::msg::ObstacleArrayMsg custom_narrow_obstacle_msg_; //!< Copy of the most recent obstacle message
 
-  costmap_converter_msgs::msg::ObstacleArrayMsg custom_fill_grade_obstacle_msg_; //!< Copy of the most recent obstacle message
+  costmap_converter_msgs::msg::ObstacleArrayMsg custom_static_obstacle_msg_; //!< Copy of the most recent obstacle message
 
   rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr via_points_sub_; //!< Subscriber for custom via-points received via a Path msg.
   bool custom_via_points_active_; //!< Keep track whether valid via-points have been received from via_points_sub_

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -255,10 +255,19 @@ protected:
 
 
     /**
-     * @brief Callback for custom obstacles that are not obtained from the costmap
+     * @brief Callback for custom narrow aisle obstacles that are not obtained from the costmap.
+     * Adjust Pallet Goal Action server provides this obstacles
      * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
      */
     void customNarrowObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
+
+
+    /**
+     * @brief Callback for custom obstacles that are not obtained from the costmap
+     * Camera server provides this obstacles
+     * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
+     */
+    void customFillGradeObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
   
    /**
     * @brief Callback for custom via-points
@@ -397,12 +406,16 @@ private:
 
   //std::shared_ptr< dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig> > dynamic_recfg_; //!< Dynamic reconfigure server to allow config modifications at runtime
   rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
-  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_narrow_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
+  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_narrow_obst_sub_; //!< Subscriber for custom narrow obstacles received via a ObstacleMsg.
+  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_fill_grade_obst_sub_; //!< Subscriber for custom fill grade obstacles received via a ObstacleMsg.
   std::mutex custom_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   std::mutex custom_narrow_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
+  std::mutex custom_fill_grade_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   costmap_converter_msgs::msg::ObstacleArrayMsg custom_obstacle_msg_; //!< Copy of the most recent obstacle message
 
   costmap_converter_msgs::msg::ObstacleArrayMsg custom_narrow_obstacle_msg_; //!< Copy of the most recent obstacle message
+
+  costmap_converter_msgs::msg::ObstacleArrayMsg custom_fill_grade_obstacle_msg_; //!< Copy of the most recent obstacle message
 
   rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr via_points_sub_; //!< Subscriber for custom via-points received via a Path msg.
   bool custom_via_points_active_; //!< Keep track whether valid via-points have been received from via_points_sub_

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -267,7 +267,7 @@ protected:
      * Camera server provides this obstacles
      * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
      */
-    void customFillGradeObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
+    void customStaticObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
   
    /**
     * @brief Callback for custom via-points

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -45,7 +45,7 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "odom_topic", rclcpp::ParameterValue(odom_topic));
   nh->declare_parameter(name + "." + "custom_obst_topic", rclcpp::ParameterValue(custom_obst_topic));
   nh->declare_parameter(name + "." + "custom_narrow_obst_topic", rclcpp::ParameterValue(custom_narrow_obst_topic));
-  nh->declare_parameter(name + "." + "custom_fill_grade_obst_topic", rclcpp::ParameterValue(custom_fill_grade_obst_topic));
+  nh->declare_parameter(name + "." + "custom_static_obst_topic", rclcpp::ParameterValue(custom_static_obst_topic));
   nh->declare_parameter(name + "." + "map_frame", rclcpp::ParameterValue(map_frame));
   
   // Trajectory
@@ -178,7 +178,7 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "odom_topic", odom_topic, odom_topic);
   nh->get_parameter_or(name + "." + "custom_obst_topic", custom_obst_topic, custom_obst_topic);
   nh->get_parameter_or(name + "." + "custom_narrow_obst_topic", custom_narrow_obst_topic, custom_narrow_obst_topic);
-  nh->get_parameter_or(name + "." + "custom_fill_grade_obst_topic", custom_fill_grade_obst_topic, custom_fill_grade_obst_topic);
+  nh->get_parameter_or(name + "." + "custom_static_obst_topic", custom_static_obst_topic, custom_static_obst_topic);
   nh->get_parameter_or(name + "." + "map_frame", map_frame, map_frame);
   
   // Trajectory

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -43,8 +43,9 @@ namespace teb_local_planner
 
 void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, const std::string name) {
   nh->declare_parameter(name + "." + "odom_topic", rclcpp::ParameterValue(odom_topic));
-  nh->declare_parameter(name + "." + "custom_narrow_obst_topic", rclcpp::ParameterValue(custom_narrow_obst_topic));
   nh->declare_parameter(name + "." + "custom_obst_topic", rclcpp::ParameterValue(custom_obst_topic));
+  nh->declare_parameter(name + "." + "custom_narrow_obst_topic", rclcpp::ParameterValue(custom_narrow_obst_topic));
+  nh->declare_parameter(name + "." + "custom_fill_grade_obst_topic", rclcpp::ParameterValue(custom_fill_grade_obst_topic));
   nh->declare_parameter(name + "." + "map_frame", rclcpp::ParameterValue(map_frame));
   
   // Trajectory
@@ -175,8 +176,9 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
 void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::SharedPtr nh, const std::string name)
 {
   nh->get_parameter_or(name + "." + "odom_topic", odom_topic, odom_topic);
-  nh->get_parameter_or(name + "." + "custom_narrow_obst_topic", custom_narrow_obst_topic, custom_narrow_obst_topic);
   nh->get_parameter_or(name + "." + "custom_obst_topic", custom_obst_topic, custom_obst_topic);
+  nh->get_parameter_or(name + "." + "custom_narrow_obst_topic", custom_narrow_obst_topic, custom_narrow_obst_topic);
+  nh->get_parameter_or(name + "." + "custom_fill_grade_obst_topic", custom_fill_grade_obst_topic, custom_fill_grade_obst_topic);
   nh->get_parameter_or(name + "." + "map_frame", map_frame, map_frame);
   
   // Trajectory

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -187,7 +187,7 @@ void TebLocalPlannerROS::initialize()
               rclcpp::SystemDefaultsQoS(),
               std::bind(&TebLocalPlannerROS::customNarrowObstacleCB, this, std::placeholders::_1));
 
-    // setup callback for custom fill grade obstacles
+    // setup callback for custom static obstacles
       custom_static_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
               cfg_->custom_static_obst_topic,
               rclcpp::SystemDefaultsQoS(),

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -181,11 +181,17 @@ void TebLocalPlannerROS::initialize()
                 rclcpp::SystemDefaultsQoS(),
                 std::bind(&TebLocalPlannerROS::customObstacleCB, this, std::placeholders::_1));
 
-      // setup callback for custom obstacles
+     // setup callback for custom narrow aisle obstacles
       custom_narrow_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
               cfg_->custom_narrow_obst_topic,
               rclcpp::SystemDefaultsQoS(),
               std::bind(&TebLocalPlannerROS::customNarrowObstacleCB, this, std::placeholders::_1));
+
+    // setup callback for custom fill grade obstacles
+      custom_fill_grade_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
+              cfg_->custom_fill_grade_obst_topic,
+              rclcpp::SystemDefaultsQoS(),
+              std::bind(&TebLocalPlannerROS::customFillGradeObstacleCB, this, std::placeholders::_1));
 
     // setup callback for custom via-points
     via_points_sub_ = nh_->create_subscription<nav_msgs::msg::Path>(
@@ -603,6 +609,8 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
 
   std::lock_guard<std::mutex> l2(custom_narrow_obst_mutex_);
 
+  std::lock_guard<std::mutex> l3(custom_fill_grade_obst_mutex_);
+
   if (!custom_obstacle_msg_.obstacles.empty()) {
       // We only use the global header to specify the obstacle coordinate system instead of individual ones
       Eigen::Affine3d obstacle_to_map_eig;
@@ -665,73 +673,136 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
 
       }
   }
-      // ADD Narrow isle obstacles
-        if (!custom_narrow_obstacle_msg_.obstacles.empty())
-        {
-            // We only use the global header to specify the obstacle coordinate system instead of individual ones
-            Eigen::Affine3d obstacle_to_map_eig;
-            try
-            {
-                geometry_msgs::msg::TransformStamped obstacle_to_map = tf_->lookupTransform(
-                        global_frame_, tf2::timeFromSec(0),
-                        custom_narrow_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
-                        custom_narrow_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
-                obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
-                //tf2::fromMsg(obstacle_to_map.transform, obstacle_to_map_eig);
-            }
-            catch (tf2::TransformException ex)
-            {
-                RCLCPP_ERROR(nh_->get_logger(), "%s",ex.what());
-                obstacle_to_map_eig.setIdentity();
-            }
-
-            for (size_t i=0; i<custom_narrow_obstacle_msg_.obstacles.size(); ++i) {
-                if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 &&
-                    custom_narrow_obstacle_msg_.obstacles.at(i).radius > 0) // circle
-                {
-                    Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                        custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                        custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
-                    obstacles_.push_back(ObstaclePtr(new CircularObstacle((obstacle_to_map_eig * pos).head(2),
-                                                                          custom_narrow_obstacle_msg_.obstacles.at(
-                                                                                  i).radius)));
-                } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1) // point
-                {
-                    Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                        custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                        custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
-                    obstacles_.push_back(ObstaclePtr(new PointObstacle((obstacle_to_map_eig * pos).head(2))));
-                } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2) // line
-                {
-                    Eigen::Vector3d line_start(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                               custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                               custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
-                    Eigen::Vector3d line_end(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
-                                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
-                                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().z);
-                    obstacles_.push_back(ObstaclePtr(new LineObstacle((obstacle_to_map_eig * line_start).head(2),
-                                                                      (obstacle_to_map_eig * line_end).head(2))));
-                } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.empty()) {
-                    RCLCPP_INFO(nh_->get_logger(),
-                                "Invalid custom obstacle received. List of polygon vertices is empty. Skipping...");
-                    continue;
-                } else // polygon
-                {
-                    PolygonObstacle *polyobst = new PolygonObstacle;
-                    for (size_t j = 0; j < custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j) {
-                        Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
-                                            custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
-                                            custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].z);
-                        polyobst->pushBackVertex((obstacle_to_map_eig * pos).head(2));
-                    }
-                    polyobst->finalizePolygon();
-                    obstacles_.push_back(ObstaclePtr(polyobst));
-                }
-                if(!obstacles_.empty())
-                    obstacles_.back()->setCentroidVelocity(custom_narrow_obstacle_msg_.obstacles[i].velocities, custom_narrow_obstacle_msg_.obstacles[i].orientation);
-
-            }
-        }
+  // ADD Narrow isle obstacles
+  if (!custom_narrow_obstacle_msg_.obstacles.empty())
+  {
+      // We only use the global header to specify the obstacle coordinate system instead of individual ones
+      Eigen::Affine3d obstacle_to_map_eig;
+      try
+      {
+          geometry_msgs::msg::TransformStamped obstacle_to_map = tf_->lookupTransform(
+                  global_frame_, tf2::timeFromSec(0),
+                  custom_narrow_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
+                  custom_narrow_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
+          obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
+          //tf2::fromMsg(obstacle_to_map.transform, obstacle_to_map_eig);
+      }
+      catch (tf2::TransformException ex)
+      {
+          RCLCPP_ERROR(nh_->get_logger(), "%s",ex.what());
+          obstacle_to_map_eig.setIdentity();
+      }
+      for (size_t i=0; i<custom_narrow_obstacle_msg_.obstacles.size(); ++i) {
+          if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 &&
+              custom_narrow_obstacle_msg_.obstacles.at(i).radius > 0) // circle
+          {
+              Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              obstacles_.push_back(ObstaclePtr(new CircularObstacle((obstacle_to_map_eig * pos).head(2),
+                                                                    custom_narrow_obstacle_msg_.obstacles.at(
+                                                                            i).radius)));
+          } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1) // point
+          {
+              Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              obstacles_.push_back(ObstaclePtr(new PointObstacle((obstacle_to_map_eig * pos).head(2))));
+          } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2) // line
+          {
+              Eigen::Vector3d line_start(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                         custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                         custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              Eigen::Vector3d line_end(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
+                                       custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
+                                       custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().z);
+              obstacles_.push_back(ObstaclePtr(new LineObstacle((obstacle_to_map_eig * line_start).head(2),
+                                                                (obstacle_to_map_eig * line_end).head(2))));
+          } else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.empty()) {
+              RCLCPP_INFO(nh_->get_logger(),
+                          "Invalid custom obstacle received. List of polygon vertices is empty. Skipping...");
+              continue;
+          } else // polygon
+          {
+              PolygonObstacle *polyobst = new PolygonObstacle;
+              for (size_t j = 0; j < custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j) {
+                  Eigen::Vector3d pos(custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
+                                      custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
+                                      custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].z);
+                  polyobst->pushBackVertex((obstacle_to_map_eig * pos).head(2));
+              }
+              polyobst->finalizePolygon();
+              obstacles_.push_back(ObstaclePtr(polyobst));
+          }
+          if(!obstacles_.empty())
+              obstacles_.back()->setCentroidVelocity(custom_narrow_obstacle_msg_.obstacles[i].velocities, custom_narrow_obstacle_msg_.obstacles[i].orientation);
+       }
+  }
+  // ADD fill_grade isle obstacles
+  if (!custom_fill_grade_obstacle_msg_.obstacles.empty())
+  {
+      // We only use the global header to specify the obstacle coordinate system instead of individual ones
+      Eigen::Affine3d obstacle_to_map_eig;
+      try
+      {
+          geometry_msgs::msg::TransformStamped obstacle_to_map = tf_->lookupTransform(
+                  global_frame_, tf2::timeFromSec(0),
+                  custom_fill_grade_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
+                  custom_fill_grade_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
+          obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
+          //tf2::fromMsg(obstacle_to_map.transform, obstacle_to_map_eig);
+      }
+      catch (tf2::TransformException ex)
+      {
+          RCLCPP_ERROR(nh_->get_logger(), "%s",ex.what());
+          obstacle_to_map_eig.setIdentity();
+      }
+      for (size_t i=0; i<custom_fill_grade_obstacle_msg_.obstacles.size(); ++i) {
+          if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 &&
+              custom_fill_grade_obstacle_msg_.obstacles.at(i).radius > 0) // circle
+          {
+              Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              obstacles_.push_back(ObstaclePtr(new CircularObstacle((obstacle_to_map_eig * pos).head(2),
+                                                                    custom_fill_grade_obstacle_msg_.obstacles.at(
+                                                                            i).radius)));
+          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1) // point
+          {
+              Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              obstacles_.push_back(ObstaclePtr(new PointObstacle((obstacle_to_map_eig * pos).head(2))));
+          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2) // line
+          {
+              Eigen::Vector3d line_start(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                         custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                         custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              Eigen::Vector3d line_end(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
+                                       custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
+                                       custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().z);
+              obstacles_.push_back(ObstaclePtr(new LineObstacle((obstacle_to_map_eig * line_start).head(2),
+                                                                (obstacle_to_map_eig * line_end).head(2))));
+          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.empty()) {
+              RCLCPP_INFO(nh_->get_logger(),
+                          "Invalid custom obstacle received. List of polygon vertices is empty. Skipping...");
+              continue;
+          } else // polygon
+          {
+              PolygonObstacle *polyobst = new PolygonObstacle;
+              for (size_t j = 0; j < custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j) {
+                  Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
+                                      custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
+                                      custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].z);
+                  polyobst->pushBackVertex((obstacle_to_map_eig * pos).head(2));
+              }
+              polyobst->finalizePolygon();
+              obstacles_.push_back(ObstaclePtr(polyobst));
+          }
+          if(!obstacles_.empty())
+              obstacles_.back()->setCentroidVelocity(custom_fill_grade_obstacle_msg_.obstacles[i].velocities, custom_fill_grade_obstacle_msg_.obstacles[i].orientation);
+       }
+  }
 }
 
 
@@ -1165,6 +1236,12 @@ void TebLocalPlannerROS::customNarrowObstacleCB(const costmap_converter_msgs::ms
 {
     std::lock_guard<std::mutex> l2(custom_narrow_obst_mutex_);
     custom_narrow_obstacle_msg_ = *obst_msg;
+}
+
+void TebLocalPlannerROS::customFillGradeObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg)
+{
+    std::lock_guard<std::mutex> l3(custom_fill_grade_obst_mutex_);
+    custom_fill_grade_obstacle_msg_ = *obst_msg;
 }
 
 void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::msg::Path::ConstSharedPtr via_points_msg)

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -188,8 +188,8 @@ void TebLocalPlannerROS::initialize()
               std::bind(&TebLocalPlannerROS::customNarrowObstacleCB, this, std::placeholders::_1));
 
     // setup callback for custom fill grade obstacles
-      custom_fill_grade_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
-              cfg_->custom_fill_grade_obst_topic,
+      custom_static_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
+              cfg_->custom_static_obst_topic,
               rclcpp::SystemDefaultsQoS(),
               std::bind(&TebLocalPlannerROS::customFillGradeObstacleCB, this, std::placeholders::_1));
 
@@ -609,7 +609,7 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
 
   std::lock_guard<std::mutex> l2(custom_narrow_obst_mutex_);
 
-  std::lock_guard<std::mutex> l3(custom_fill_grade_obst_mutex_);
+  std::lock_guard<std::mutex> l3(custom_static_obst_mutex_);
 
   if (!custom_obstacle_msg_.obstacles.empty()) {
       // We only use the global header to specify the obstacle coordinate system instead of individual ones
@@ -738,8 +738,8 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
               obstacles_.back()->setCentroidVelocity(custom_narrow_obstacle_msg_.obstacles[i].velocities, custom_narrow_obstacle_msg_.obstacles[i].orientation);
        }
   }
-  // ADD fill_grade isle obstacles
-  if (!custom_fill_grade_obstacle_msg_.obstacles.empty())
+  // ADD static isle obstacles
+  if (!custom_static_obstacle_msg_.obstacles.empty())
   {
       // We only use the global header to specify the obstacle coordinate system instead of individual ones
       Eigen::Affine3d obstacle_to_map_eig;
@@ -747,8 +747,8 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
       {
           geometry_msgs::msg::TransformStamped obstacle_to_map = tf_->lookupTransform(
                   global_frame_, tf2::timeFromSec(0),
-                  custom_fill_grade_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
-                  custom_fill_grade_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
+                  custom_static_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
+                  custom_static_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
           obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
           //tf2::fromMsg(obstacle_to_map.transform, obstacle_to_map_eig);
       }
@@ -757,50 +757,50 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
           RCLCPP_ERROR(nh_->get_logger(), "%s",ex.what());
           obstacle_to_map_eig.setIdentity();
       }
-      for (size_t i=0; i<custom_fill_grade_obstacle_msg_.obstacles.size(); ++i) {
-          if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 &&
-              custom_fill_grade_obstacle_msg_.obstacles.at(i).radius > 0) // circle
+      for (size_t i=0; i<custom_static_obstacle_msg_.obstacles.size(); ++i) {
+          if (custom_static_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 &&
+              custom_static_obstacle_msg_.obstacles.at(i).radius > 0) // circle
           {
-              Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              Eigen::Vector3d pos(custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
               obstacles_.push_back(ObstaclePtr(new CircularObstacle((obstacle_to_map_eig * pos).head(2),
-                                                                    custom_fill_grade_obstacle_msg_.obstacles.at(
+                                                                    custom_static_obstacle_msg_.obstacles.at(
                                                                             i).radius)));
-          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1) // point
+          } else if (custom_static_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1) // point
           {
-              Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                  custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              Eigen::Vector3d pos(custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                  custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                  custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
               obstacles_.push_back(ObstaclePtr(new PointObstacle((obstacle_to_map_eig * pos).head(2))));
-          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2) // line
+          } else if (custom_static_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2) // line
           {
-              Eigen::Vector3d line_start(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
-                                         custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
-                                         custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
-              Eigen::Vector3d line_end(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
-                                       custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
-                                       custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.back().z);
+              Eigen::Vector3d line_start(custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                         custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                         custom_static_obstacle_msg_.obstacles.at(i).polygon.points.front().z);
+              Eigen::Vector3d line_end(custom_static_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
+                                       custom_static_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
+                                       custom_static_obstacle_msg_.obstacles.at(i).polygon.points.back().z);
               obstacles_.push_back(ObstaclePtr(new LineObstacle((obstacle_to_map_eig * line_start).head(2),
                                                                 (obstacle_to_map_eig * line_end).head(2))));
-          } else if (custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.empty()) {
+          } else if (custom_static_obstacle_msg_.obstacles.at(i).polygon.points.empty()) {
               RCLCPP_INFO(nh_->get_logger(),
                           "Invalid custom obstacle received. List of polygon vertices is empty. Skipping...");
               continue;
           } else // polygon
           {
               PolygonObstacle *polyobst = new PolygonObstacle;
-              for (size_t j = 0; j < custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j) {
-                  Eigen::Vector3d pos(custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
-                                      custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
-                                      custom_fill_grade_obstacle_msg_.obstacles.at(i).polygon.points[j].z);
+              for (size_t j = 0; j < custom_static_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j) {
+                  Eigen::Vector3d pos(custom_static_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
+                                      custom_static_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
+                                      custom_static_obstacle_msg_.obstacles.at(i).polygon.points[j].z);
                   polyobst->pushBackVertex((obstacle_to_map_eig * pos).head(2));
               }
               polyobst->finalizePolygon();
               obstacles_.push_back(ObstaclePtr(polyobst));
           }
           if(!obstacles_.empty())
-              obstacles_.back()->setCentroidVelocity(custom_fill_grade_obstacle_msg_.obstacles[i].velocities, custom_fill_grade_obstacle_msg_.obstacles[i].orientation);
+              obstacles_.back()->setCentroidVelocity(custom_static_obstacle_msg_.obstacles[i].velocities, custom_static_obstacle_msg_.obstacles[i].orientation);
        }
   }
 }
@@ -1240,8 +1240,8 @@ void TebLocalPlannerROS::customNarrowObstacleCB(const costmap_converter_msgs::ms
 
 void TebLocalPlannerROS::customFillGradeObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg)
 {
-    std::lock_guard<std::mutex> l3(custom_fill_grade_obst_mutex_);
-    custom_fill_grade_obstacle_msg_ = *obst_msg;
+    std::lock_guard<std::mutex> l3(custom_static_obst_mutex_);
+    custom_static_obstacle_msg_ = *obst_msg;
 }
 
 void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::msg::Path::ConstSharedPtr via_points_msg)

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -191,7 +191,7 @@ void TebLocalPlannerROS::initialize()
       custom_static_obst_sub_ = nh_->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
               cfg_->custom_static_obst_topic,
               rclcpp::SystemDefaultsQoS(),
-              std::bind(&TebLocalPlannerROS::customFillGradeObstacleCB, this, std::placeholders::_1));
+              std::bind(&TebLocalPlannerROS::customStaticObstacleCB, this, std::placeholders::_1));
 
     // setup callback for custom via-points
     via_points_sub_ = nh_->create_subscription<nav_msgs::msg::Path>(
@@ -1238,7 +1238,7 @@ void TebLocalPlannerROS::customNarrowObstacleCB(const costmap_converter_msgs::ms
     custom_narrow_obstacle_msg_ = *obst_msg;
 }
 
-void TebLocalPlannerROS::customFillGradeObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg)
+void TebLocalPlannerROS::customStaticObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg)
 {
     std::lock_guard<std::mutex> l3(custom_static_obst_mutex_);
     custom_static_obstacle_msg_ = *obst_msg;


### PR DESCRIPTION
I've added an additional obstacle topic to subscribe to, for fill grade obstacles  to TEB. Now by specifying the **`custom_fill_grade_obst_topic`**  the controllers can subscribe to fill grade obstacles explicitly. 

`custom_fill_grade_obst_topic : "fill_grade_obstacles" // Default value that each controller will use.`

To make use of this feature, we need to publish the fill grade obstacles to "fill_grade_obstacles". For the controllers which won't use fill grade obstacles, we can define the topic as eg. `custom_fill_grade_obst_topic : "empty_topic"` 