### PR TITLE
Amrfm 874 Detect obstacles with kinect and stop

### DIFF
--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -54,9 +54,9 @@ grp_trajectory.add("feasibility_check_no_poses",   int_t,   0,
   "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
   5, 0, 50) 
 
-grp_trajectory.add("feasibility_check",   int_t,   0,
-  "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
-  20, 0, 50)
+grp_trajectory.add("feasibility_check",   bool_t,   0,
+  "If True, feasibility check of planned path is activated",
+  False)
 
 grp_trajectory.add("exact_arc_length",   bool_t,   0,
   "If true, the planner uses the exact arc length in velocity, acceleration and turning rate computations [-> increased cpu time], otherwise the euclidean approximation is used.",

--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -53,7 +53,11 @@ grp_trajectory.add("force_reinit_new_goal_angular",   double_t,   0,
 grp_trajectory.add("feasibility_check_no_poses",   int_t,   0,
   "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
   5, 0, 50) 
-  
+
+grp_trajectory.add("feasibility_check",   int_t,   0,
+  "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
+  20, 0, 50)
+
 grp_trajectory.add("exact_arc_length",   bool_t,   0,
   "If true, the planner uses the exact arc length in velocity, acceleration and turning rate computations [-> increased cpu time], otherwise the euclidean approximation is used.",
   False)    

--- a/teb_local_planner/include/teb_local_planner/optimal_planner.h
+++ b/teb_local_planner/include/teb_local_planner/optimal_planner.h
@@ -515,7 +515,18 @@ public:
    */
   virtual bool isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec, double inscribed_radius = 0.0,
           double circumscribed_radius=0.0, int look_ahead_idx=-1);
-  
+
+   /**
+   * @brief Check whether the footprint of the robot at the pose touches an obstacle or not.
+   *
+   * @param pose2d Pose to check
+   * @param costmap_model Pointer to the costmap model
+   * @param footprint_spec The specification of the footprint of the robot in world coordinates
+   * @return \c true, if the robot pose is valid, \c false otherwise.
+   */
+  virtual bool isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_critics::ObstacleFootprintCritic* costmap_model,
+                           const std::vector<geometry_msgs::msg::Point>& footprint_spec);
+
   //@}
   
 protected:

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -88,6 +88,7 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
+    int feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
     int control_look_ahead_poses; //! Index of the pose used to extract the velocity command
@@ -266,6 +267,7 @@ public:
     trajectory.force_reinit_new_goal_dist = 1;
     trajectory.force_reinit_new_goal_angular = 0.5 * M_PI;
     trajectory.feasibility_check_no_poses = 5;
+    trajectory.feasibility_check = false;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;
     trajectory.control_look_ahead_poses = 1;

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -88,7 +88,7 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
-    int feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
+    bool feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
     int control_look_ahead_poses; //! Index of the pose used to extract the velocity command

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1256,8 +1256,8 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
       double delta_rot = g2o::normalize_theta(g2o::normalize_theta(teb().Pose(i+1).theta()) -
                                               g2o::normalize_theta(teb().Pose(i).theta()));
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
-      RCLCPP_DEBUG(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
-      RCLCPP_DEBUG(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
+      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
+      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 
@@ -1288,7 +1288,7 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
                            const std::vector<geometry_msgs::msg::Point>& footprint_spec)
 {
   try {
-    RCLCPP_DEBUG(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
+    RCLCPP_INFO(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
     if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
       return false;
     }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -106,6 +106,7 @@ void TebOptimalPlanner::initialize(nav2_util::LifecycleNode::SharedPtr node, con
   vel_goal_.second.linear.y = 0;
   vel_goal_.second.angular.z = 0;
   initialized_ = true;
+  setVisualization(visual);
 }
 
 
@@ -1239,7 +1240,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
   for (int i=0; i <= look_ahead_idx; ++i)
   {
     teb().Pose(i).toPoseMsg(pose2d);
-    if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
+    if (!isPoseValid(pose2d, costmap_model, footprint_spec)){
       if (visualization_)
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
@@ -1266,8 +1267,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
                                                            delta_rot / (n_additional_samples + 1.0));
           intermediate_pose.toPoseMsg(pose2d);
 
-          if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 )
-          {
+          if (!isPoseValid(pose2d, costmap_model, footprint_spec)){
             if (visualization_)
             {
               visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1256,6 +1256,8 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
       double delta_rot = g2o::normalize_theta(g2o::normalize_theta(teb().Pose(i+1).theta()) -
                                               g2o::normalize_theta(teb().Pose(i).theta()));
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
+      RCLCPP_ERROR(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
+      RCLCPP_ERROR(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 
@@ -1286,6 +1288,7 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
                            const std::vector<geometry_msgs::msg::Point>& footprint_spec)
 {
   try {
+    RCLCPP_ERROR(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
     if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
       return false;
     }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1256,8 +1256,6 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
       double delta_rot = g2o::normalize_theta(g2o::normalize_theta(teb().Pose(i+1).theta()) -
                                               g2o::normalize_theta(teb().Pose(i).theta()));
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
-      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
-      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f > %.2f", delta_dist.norm() , inscribed_radius);
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 
@@ -1288,7 +1286,7 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
                            const std::vector<geometry_msgs::msg::Point>& footprint_spec)
 {
   try {
-    RCLCPP_INFO(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
+    RCLCPP_INFO(node_->get_logger(), "CostmapScore: %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
     if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
       return false;
     }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1285,7 +1285,6 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
                            const std::vector<geometry_msgs::msg::Point>& footprint_spec)
 {
   try {
-    RCLCPP_INFO(node_->get_logger(), "CostmapScore: %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
     if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) > 0 ) {
       return false;
     }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1256,8 +1256,8 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
       double delta_rot = g2o::normalize_theta(g2o::normalize_theta(teb().Pose(i+1).theta()) -
                                               g2o::normalize_theta(teb().Pose(i).theta()));
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
-      RCLCPP_ERROR(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
-      RCLCPP_ERROR(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
+      RCLCPP_DEBUG(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
+      RCLCPP_DEBUG(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 
@@ -1288,7 +1288,7 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
                            const std::vector<geometry_msgs::msg::Point>& footprint_spec)
 {
   try {
-    RCLCPP_ERROR(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
+    RCLCPP_DEBUG(node_->get_logger(), "Costmap Mod out \n %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
     if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
       return false;
     }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1287,7 +1287,7 @@ bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_criti
 {
   try {
     RCLCPP_INFO(node_->get_logger(), "CostmapScore: %.2f", costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)));
-    if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) < 0 ) {
+    if ( costmap_model->scorePose(pose2d, dwb_critics::getOrientedFootprint(pose2d, footprint_spec)) > 0 ) {
       return false;
     }
   } catch (...) {

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1257,7 +1257,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
                                               g2o::normalize_theta(teb().Pose(i).theta()));
       Eigen::Vector2d delta_dist = teb().Pose(i+1).position()-teb().Pose(i).position();
       RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f  < %.2f",cfg_->trajectory.min_resolution_collision_check_angular, delta_rot);
-      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f > %.2f",cfg_->delta_dist.norm() , inscribed_radius);
+      RCLCPP_INFO(node_->get_logger(), "Check feas with \n %.2f > %.2f", delta_dist.norm() , inscribed_radius);
       if(fabs(delta_rot) > cfg_->trajectory.min_resolution_collision_check_angular || delta_dist.norm() > inscribed_radius)
       {
         int n_additional_samples = std::max(std::ceil(fabs(delta_rot) / cfg_->trajectory.min_resolution_collision_check_angular), 

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -64,6 +64,7 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "force_reinit_new_goal_dist", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_dist));
   nh->declare_parameter(name + "." + "force_reinit_new_goal_angular", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_angular));
   nh->declare_parameter(name + "." + "feasibility_check_no_poses", rclcpp::ParameterValue(trajectory.feasibility_check_no_poses));
+  nh->declare_parameter(name + "." + "feasibility_check", rclcpp::ParameterValue(trajectory.feasibility_check));
   nh->declare_parameter(name + "." + "publish_feedback", rclcpp::ParameterValue(trajectory.publish_feedback));
   nh->declare_parameter(name + "." + "min_resolution_collision_check_angular", rclcpp::ParameterValue(trajectory.min_resolution_collision_check_angular));
   nh->declare_parameter(name + "." + "control_look_ahead_poses", rclcpp::ParameterValue(trajectory.control_look_ahead_poses));
@@ -197,6 +198,7 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_dist", trajectory.force_reinit_new_goal_dist, trajectory.force_reinit_new_goal_dist);
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_angular", trajectory.force_reinit_new_goal_angular, trajectory.force_reinit_new_goal_angular);
   nh->get_parameter_or(name + "." + "feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
+  nh->get_parameter_or(name + "." + "feasibility_check", trajectory.feasibility_check, trajectory.feasibility_check);
   nh->get_parameter_or(name + "." + "publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
   nh->get_parameter_or(name + "." + "min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);
   nh->get_parameter_or(name + "." + "control_look_ahead_poses", trajectory.control_look_ahead_poses, trajectory.control_look_ahead_poses);

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -436,7 +436,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   }
 
   bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
-  if (!feasible)
+  if (!feasible &&  && cfg_->trajectory.feasibility_check)
   {
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
 
@@ -492,7 +492,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   
   // a feasible solution should be found, reset counter
   no_infeasible_plans_ = 0;
-  
+
   // store last command (for recovery analysis etc.)
   last_cmd_ = cmd_vel.twist;
   

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -434,24 +434,23 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     footprint_spec_ = costmap_ros_->getRobotFootprint();
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
-  // Always true since we do not use costmap. isTrajectoryFeasible only uses costmap to check feasibility.
-  // Therefore we do not need to check whether trajectory feasible or not.
-  bool feasible = true; //planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
-  //  if (!feasible)
-  //  {
-  //    cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
-  //
-  //    // now we reset everything to start again with the initialization of new trajectories.
-  //    planner_->clearPlanner();
-  //
-  //    ++no_infeasible_plans_; // increase number of infeasible solutions in a row
-  //    time_last_infeasible_plan_ = nh_->now();
-  //    last_cmd_ = cmd_vel.twist;
-  //
-  //    throw nav2_core::PlannerException(
-  //      std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
-  //    );
-  //  }
+
+  bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses, cfg_->trajectory.feasibility_check_lookahead_distance);
+  if (!feasible)
+  {
+    cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
+
+    // now we reset everything to start again with the initialization of new trajectories.
+    planner_->clearPlanner();
+
+    ++no_infeasible_plans_; // increase number of infeasible solutions in a row
+    time_last_infeasible_plan_ = nh_->now();
+    last_cmd_ = cmd_vel.twist;
+
+    throw nav2_core::PlannerException(
+      std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
+    );
+  }
 
   // Get the velocity command for this sampling interval
   if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z, cfg_->trajectory.control_look_ahead_poses))

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -436,7 +436,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   }
 
   bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
-  if (!feasible &&  && cfg_->trajectory.feasibility_check)
+  if (!feasible && cfg_->trajectory.feasibility_check)
   {
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
 

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -436,6 +436,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   }
 
   bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
+  RCLCPP_INFO(nh_->get_logger(), "Feas check: %d !", feasible);
   if (!feasible)
   {
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -435,7 +435,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
 
-  bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses, cfg_->trajectory.feasibility_check_lookahead_distance);
+  bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
   if (!feasible)
   {
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -436,7 +436,6 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   }
 
   bool feasible = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
-  RCLCPP_INFO(nh_->get_logger(), "Feas check: %d !", feasible);
   if (!feasible)
   {
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;


### PR DESCRIPTION
We're bringing the feasibility check back. So now, with using kinect, we can detect obstacles under the lidar field and stop before hitting them. This is by default turned off, one can turn it on by adding
feasibility_check: True
to the corresponding FollowPath config.