### PR TITLE
Amrfm 23 slowdown and stop for costmap obstacles

### DIFF
--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -52,15 +52,11 @@ grp_trajectory.add("force_reinit_new_goal_angular",   double_t,   0,
 	
 grp_trajectory.add("feasibility_check_no_poses",   int_t,   0,
   "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
-  5, 0, 50)
-
-grp_trajectory.add("feasibility_check_slowdown_poses",   int_t,   0,
-  "How many poses to use for linear slowdown for feasibility check.",
-  5, 0, 50)
+  1, 0, 50)
 
 grp_trajectory.add("feasibility_check_stop_poses",   int_t,   0,
   "How many poses to use for linear slowdown for feasibility check.",
-  5, 0, 50)
+  1, 0, 20)
 
 
 grp_trajectory.add("feasibility_check",   bool_t,   0,

--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -52,7 +52,12 @@ grp_trajectory.add("force_reinit_new_goal_angular",   double_t,   0,
 	
 grp_trajectory.add("feasibility_check_no_poses",   int_t,   0,
   "Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval",
-  5, 0, 50) 
+  5, 0, 50)
+
+grp_trajectory.add("feasibility_check_slowdown_poses",   int_t,   0,
+  "How many poses to use for linear slowdown for feasibility check.",
+  5, 0, 50)
+
 
 grp_trajectory.add("feasibility_check",   bool_t,   0,
   "If True, feasibility check of planned path is activated",

--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -58,6 +58,10 @@ grp_trajectory.add("feasibility_check_slowdown_poses",   int_t,   0,
   "How many poses to use for linear slowdown for feasibility check.",
   5, 0, 50)
 
+grp_trajectory.add("feasibility_check_stop_poses",   int_t,   0,
+  "How many poses to use for linear slowdown for feasibility check.",
+  5, 0, 50)
+
 
 grp_trajectory.add("feasibility_check",   bool_t,   0,
   "If True, feasibility check of planned path is activated",

--- a/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
+++ b/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
@@ -220,8 +220,8 @@ public:
    * @param inscribed_radius The radius of the inscribed circle of the robot
    * @param circumscribed_radius The radius of the circumscribed circle of the robot
    * @param look_ahead_idx Number of poses along the trajectory that should be verified, if -1, the complete trajectory will be checked.
-   * @return \c true, if the robot footprint along the first part of the trajectory intersects with
-   *         any obstacle in the costmap, \c false otherwise.
+   * @return \c int >= 0, if the robot footprint along the first part of the trajectory intersects with
+   *         any obstacle in the costmap (return the index of the pose that intersects), \c -1 otherwise.
    */
   virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                     double inscribed_radius = 0.0, double circumscribed_radius=0.0, int look_ahead_idx=-1);

--- a/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
+++ b/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
@@ -223,7 +223,7 @@ public:
    * @return \c true, if the robot footprint along the first part of the trajectory intersects with
    *         any obstacle in the costmap, \c false otherwise.
    */
-  virtual bool isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
+  virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                     double inscribed_radius = 0.0, double circumscribed_radius=0.0, int look_ahead_idx=-1);
 
   /**

--- a/teb_local_planner/include/teb_local_planner/optimal_planner.h
+++ b/teb_local_planner/include/teb_local_planner/optimal_planner.h
@@ -513,7 +513,7 @@ public:
    * @return \c true, if the robot footprint along the first part of the trajectory intersects with 
    *         any obstacle in the costmap, \c false otherwise.
    */
-  virtual bool isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec, double inscribed_radius = 0.0,
+  virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec, double inscribed_radius = 0.0,
           double circumscribed_radius=0.0, int look_ahead_idx=-1);
 
    /**

--- a/teb_local_planner/include/teb_local_planner/optimal_planner.h
+++ b/teb_local_planner/include/teb_local_planner/optimal_planner.h
@@ -510,8 +510,8 @@ public:
    * @param inscribed_radius The radius of the inscribed circle of the robot
    * @param circumscribed_radius The radius of the circumscribed circle of the robot
    * @param look_ahead_idx Number of poses along the trajectory that should be verified, if -1, the complete trajectory will be checked.
-   * @return \c true, if the robot footprint along the first part of the trajectory intersects with 
-   *         any obstacle in the costmap, \c false otherwise.
+   * @return int >= 0, if the robot footprint along the first part of the trajectory intersects with
+   *         any obstacle in the costmap (return the index of the pose that intersects), \c -1 otherwise.
    */
   virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec, double inscribed_radius = 0.0,
           double circumscribed_radius=0.0, int look_ahead_idx=-1);

--- a/teb_local_planner/include/teb_local_planner/planner_interface.h
+++ b/teb_local_planner/include/teb_local_planner/planner_interface.h
@@ -181,8 +181,8 @@ public:
    * @param inscribed_radius The radius of the inscribed circle of the robot
    * @param circumscribed_radius The radius of the circumscribed circle of the robot
    * @param look_ahead_idx Number of poses along the trajectory that should be verified, if -1, the complete trajectory will be checked.
-   * @return \c true, if the robot footprint along the first part of the trajectory intersects with 
-   *         any obstacle in the costmap, \c false otherwise.
+   * @return int >= 0, if the robot footprint along the first part of the trajectory intersects with
+   *         any obstacle in the costmap (return the index of the pose that intersects), \c -1 otherwise.
    */
   virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
         double inscribed_radius = 0.0, double circumscribed_radius=0.0, int look_ahead_idx=-1) = 0;

--- a/teb_local_planner/include/teb_local_planner/planner_interface.h
+++ b/teb_local_planner/include/teb_local_planner/planner_interface.h
@@ -184,7 +184,7 @@ public:
    * @return \c true, if the robot footprint along the first part of the trajectory intersects with 
    *         any obstacle in the costmap, \c false otherwise.
    */
-  virtual bool isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
+  virtual int isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
         double inscribed_radius = 0.0, double circumscribed_radius=0.0, int look_ahead_idx=-1) = 0;
     
   /**

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -88,7 +88,7 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
-    int feasibility_check_stop_poses; // !How many poses to use for linear slowdown for feasibility check.
+    int feasibility_check_stop_poses; // How many poses to use for linear slowdown / stop for feasibility check. TEB will slowdown until this pose, and stop for all indices lower than that.
     bool feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -88,6 +88,7 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
+    int feasibility_check_slowdown_poses; // !How many poses to use for linear slowdown for feasibility check.
     bool feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
@@ -267,6 +268,7 @@ public:
     trajectory.force_reinit_new_goal_dist = 1;
     trajectory.force_reinit_new_goal_angular = 0.5 * M_PI;
     trajectory.feasibility_check_no_poses = 5;
+    trajectory.feasibility_check_slowdown_poses = 10;
     trajectory.feasibility_check = false;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -89,6 +89,7 @@ public:
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     int feasibility_check_slowdown_poses; // !How many poses to use for linear slowdown for feasibility check.
+    int feasibility_check_stop_poses; // !How many poses to use for linear slowdown for feasibility check.
     bool feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
@@ -267,8 +268,9 @@ public:
     trajectory.exact_arc_length = false;
     trajectory.force_reinit_new_goal_dist = 1;
     trajectory.force_reinit_new_goal_angular = 0.5 * M_PI;
-    trajectory.feasibility_check_no_poses = 5;
+    trajectory.feasibility_check_no_poses = 20;
     trajectory.feasibility_check_slowdown_poses = 10;
+    trajectory.feasibility_check_stop_poses = 5;
     trajectory.feasibility_check = false;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -88,7 +88,6 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     double force_reinit_new_goal_angular; //!< Reinitialize the trajectory if a previous goal is updated with an angular difference of more than the specified value in radians (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
-    int feasibility_check_slowdown_poses; // !How many poses to use for linear slowdown for feasibility check.
     int feasibility_check_stop_poses; // !How many poses to use for linear slowdown for feasibility check.
     bool feasibility_check; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
@@ -268,9 +267,8 @@ public:
     trajectory.exact_arc_length = false;
     trajectory.force_reinit_new_goal_dist = 1;
     trajectory.force_reinit_new_goal_angular = 0.5 * M_PI;
-    trajectory.feasibility_check_no_poses = 20;
-    trajectory.feasibility_check_slowdown_poses = 10;
-    trajectory.feasibility_check_stop_poses = 5;
+    trajectory.feasibility_check_no_poses = 5;
+    trajectory.feasibility_check_stop_poses = 2;
     trajectory.feasibility_check = false;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -428,6 +428,7 @@ private:
   rclcpp::Time time_last_infeasible_plan_; //!< Store at which time stamp the last infeasible plan was detected
   double time_last_published_global_plan_; // Last published global path timestamp in seconds
   int no_infeasible_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
+  int no_infeasible_slowdown_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
   rclcpp::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected
   RotType last_preferred_rotdir_; //!< Store recent preferred turning direction
   geometry_msgs::msg::Twist last_cmd_; //!< Store the last control command generated in computeVelocityCommands()

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -428,7 +428,6 @@ private:
   rclcpp::Time time_last_infeasible_plan_; //!< Store at which time stamp the last infeasible plan was detected
   double time_last_published_global_plan_; // Last published global path timestamp in seconds
   int no_infeasible_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
-  int no_infeasible_slowdown_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
   rclcpp::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected
   RotType last_preferred_rotdir_; //!< Store recent preferred turning direction
   geometry_msgs::msg::Twist last_cmd_; //!< Store the last control command generated in computeVelocityCommands()

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -631,7 +631,7 @@ int HomotopyClassPlanner::bestTebIdx() const
   return -1;
 }
 
-bool HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
+int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                                 double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
   bool feasible = false;

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -634,7 +634,7 @@ int HomotopyClassPlanner::bestTebIdx() const
 int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                                 double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
-  int feasible = -1;
+  int feasible = 0;
   while(rclcpp::ok() && !feasible && tebs_.size() > 0)
   {
     TebOptimalPlannerPtr best = findBestTeb();
@@ -644,7 +644,7 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
       return 0;
     }
     feasible = best->isTrajectoryFeasible(costmap_model, footprint_spec, inscribed_radius, circumscribed_radius, look_ahead_idx);
-    if(!feasible)
+    if(feasible >= 0)
     {
       removeTeb(best);
       if(last_best_teb_ && (last_best_teb_ == best)) // Same plan as before.

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -635,8 +635,7 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
                                                 double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
   int feasible = 0;
-  //while(rclcpp::ok() && !feasible && tebs_.size() > 0)
-  //{
+
     TebOptimalPlannerPtr best = findBestTeb();
     if (!best)
     {
@@ -644,13 +643,7 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
       return 0;
     }
     feasible = best->isTrajectoryFeasible(costmap_model, footprint_spec, inscribed_radius, circumscribed_radius, look_ahead_idx);
-    //if(feasible >= 0)
-    //{
-    //  removeTeb(best);
-    //  if(last_best_teb_ && (last_best_teb_ == best)) // Same plan as before.
-    //    return feasible;                             // Not failing could result in oscillations between trajectories.
-    //}
-  //}
+
   return feasible;
 }
 

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -641,7 +641,7 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
     if (!best)
     {
       RCLCPP_ERROR(rclcpp::get_logger("teb_local_planner"), "Couldn't retrieve the best plan");
-      return false;
+      return 0;
     }
     feasible = best->isTrajectoryFeasible(costmap_model, footprint_spec, inscribed_radius, circumscribed_radius, look_ahead_idx);
     if(!feasible)

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -635,8 +635,8 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
                                                 double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
   int feasible = 0;
-  while(rclcpp::ok() && !feasible && tebs_.size() > 0)
-  {
+  //while(rclcpp::ok() && !feasible && tebs_.size() > 0)
+  //{
     TebOptimalPlannerPtr best = findBestTeb();
     if (!best)
     {
@@ -644,13 +644,13 @@ int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCri
       return 0;
     }
     feasible = best->isTrajectoryFeasible(costmap_model, footprint_spec, inscribed_radius, circumscribed_radius, look_ahead_idx);
-    if(feasible >= 0)
-    {
-      removeTeb(best);
-      if(last_best_teb_ && (last_best_teb_ == best)) // Same plan as before.
-        return feasible;                             // Not failing could result in oscillations between trajectories.
-    }
-  }
+    //if(feasible >= 0)
+    //{
+    //  removeTeb(best);
+    //  if(last_best_teb_ && (last_best_teb_ == best)) // Same plan as before.
+    //    return feasible;                             // Not failing could result in oscillations between trajectories.
+    //}
+  //}
   return feasible;
 }
 

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -634,7 +634,7 @@ int HomotopyClassPlanner::bestTebIdx() const
 int HomotopyClassPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                                 double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
-  bool feasible = false;
+  int feasible = -1;
   while(rclcpp::ok() && !feasible && tebs_.size() > 0)
   {
     TebOptimalPlannerPtr best = findBestTeb();

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1245,6 +1245,8 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
       }
+      RCLCPP_INFO(nh_->get_logger(), "Here.. %d", i);
+
       return i;
     }
     // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
@@ -1272,6 +1274,8 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
             {
               visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
             }
+            RCLCPP_INFO(nh_->get_logger(), "Or Here.. %d", i);
+
             return i;
           }
         }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1245,8 +1245,6 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
       }
-      RCLCPP_INFO(node_->get_logger(), "Here.. %d", i);
-
       return i;
     }
     // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
@@ -1274,8 +1272,6 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
             {
               visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
             }
-            RCLCPP_INFO(node_->get_logger(), "Or Here.. %d", i);
-
             return i;
           }
         }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1229,7 +1229,7 @@ void TebOptimalPlanner::getFullTrajectory(std::vector<teb_msgs::msg::TrajectoryP
 }
 
 
-bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
+int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic* costmap_model, const std::vector<geometry_msgs::msg::Point>& footprint_spec,
                                              double inscribed_radius, double circumscribed_radius, int look_ahead_idx)
 {
   if (look_ahead_idx < 0 || look_ahead_idx >= teb().sizePoses())
@@ -1245,7 +1245,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
       }
-      return false;
+      return -2;
     }
     // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
     // and interpolates in that case.
@@ -1272,13 +1272,13 @@ bool TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCriti
             {
               visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
             }
-            return false;
+            return i;
           }
         }
       }
     }
   }
-  return true;
+  return -1;
 }
 
 bool TebOptimalPlanner::isPoseValid(geometry_msgs::msg::Pose2D pose2d, dwb_critics::ObstacleFootprintCritic* costmap_model,

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1245,7 +1245,7 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
       }
-      RCLCPP_INFO(nh_->get_logger(), "Here.. %d", i);
+      RCLCPP_INFO(node_->get_logger(), "Here.. %d", i);
 
       return i;
     }
@@ -1274,7 +1274,7 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
             {
               visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
             }
-            RCLCPP_INFO(nh_->get_logger(), "Or Here.. %d", i);
+            RCLCPP_INFO(node_->get_logger(), "Or Here.. %d", i);
 
             return i;
           }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -1245,7 +1245,7 @@ int TebOptimalPlanner::isTrajectoryFeasible(dwb_critics::ObstacleFootprintCritic
       {
         visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
       }
-      return -2;
+      return i;
     }
     // Checks if the distance between two poses is higher than the robot radius or the orientation diff is bigger than the specified threshold
     // and interpolates in that case.

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -64,6 +64,7 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "force_reinit_new_goal_dist", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_dist));
   nh->declare_parameter(name + "." + "force_reinit_new_goal_angular", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_angular));
   nh->declare_parameter(name + "." + "feasibility_check_no_poses", rclcpp::ParameterValue(trajectory.feasibility_check_no_poses));
+  nh->declare_parameter(name + "." + "feasibility_check_slowdown_poses", rclcpp::ParameterValue(trajectory.feasibility_check_slowdown_poses));
   nh->declare_parameter(name + "." + "feasibility_check", rclcpp::ParameterValue(trajectory.feasibility_check));
   nh->declare_parameter(name + "." + "publish_feedback", rclcpp::ParameterValue(trajectory.publish_feedback));
   nh->declare_parameter(name + "." + "min_resolution_collision_check_angular", rclcpp::ParameterValue(trajectory.min_resolution_collision_check_angular));
@@ -198,6 +199,7 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_dist", trajectory.force_reinit_new_goal_dist, trajectory.force_reinit_new_goal_dist);
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_angular", trajectory.force_reinit_new_goal_angular, trajectory.force_reinit_new_goal_angular);
   nh->get_parameter_or(name + "." + "feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
+  nh->get_parameter_or(name + "." + "feasibility_check_slowdown_poses", trajectory.feasibility_check_slowdown_poses, trajectory.feasibility_check_slowdown_poses);
   nh->get_parameter_or(name + "." + "feasibility_check", trajectory.feasibility_check, trajectory.feasibility_check);
   nh->get_parameter_or(name + "." + "publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
   nh->get_parameter_or(name + "." + "min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -64,7 +64,6 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "force_reinit_new_goal_dist", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_dist));
   nh->declare_parameter(name + "." + "force_reinit_new_goal_angular", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_angular));
   nh->declare_parameter(name + "." + "feasibility_check_no_poses", rclcpp::ParameterValue(trajectory.feasibility_check_no_poses));
-  nh->declare_parameter(name + "." + "feasibility_check_slowdown_poses", rclcpp::ParameterValue(trajectory.feasibility_check_slowdown_poses));
   nh->declare_parameter(name + "." + "feasibility_check_stop_poses", rclcpp::ParameterValue(trajectory.feasibility_check_stop_poses));
   nh->declare_parameter(name + "." + "feasibility_check", rclcpp::ParameterValue(trajectory.feasibility_check));
   nh->declare_parameter(name + "." + "publish_feedback", rclcpp::ParameterValue(trajectory.publish_feedback));
@@ -200,7 +199,6 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_dist", trajectory.force_reinit_new_goal_dist, trajectory.force_reinit_new_goal_dist);
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_angular", trajectory.force_reinit_new_goal_angular, trajectory.force_reinit_new_goal_angular);
   nh->get_parameter_or(name + "." + "feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
-  nh->get_parameter_or(name + "." + "feasibility_check_slowdown_poses", trajectory.feasibility_check_slowdown_poses, trajectory.feasibility_check_slowdown_poses);
   nh->get_parameter_or(name + "." + "feasibility_check_stop_poses", trajectory.feasibility_check_stop_poses, trajectory.feasibility_check_stop_poses);
   nh->get_parameter_or(name + "." + "feasibility_check", trajectory.feasibility_check, trajectory.feasibility_check);
   nh->get_parameter_or(name + "." + "publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -65,6 +65,7 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "force_reinit_new_goal_angular", rclcpp::ParameterValue(trajectory.force_reinit_new_goal_angular));
   nh->declare_parameter(name + "." + "feasibility_check_no_poses", rclcpp::ParameterValue(trajectory.feasibility_check_no_poses));
   nh->declare_parameter(name + "." + "feasibility_check_slowdown_poses", rclcpp::ParameterValue(trajectory.feasibility_check_slowdown_poses));
+  nh->declare_parameter(name + "." + "feasibility_check_stop_poses", rclcpp::ParameterValue(trajectory.feasibility_check_stop_poses));
   nh->declare_parameter(name + "." + "feasibility_check", rclcpp::ParameterValue(trajectory.feasibility_check));
   nh->declare_parameter(name + "." + "publish_feedback", rclcpp::ParameterValue(trajectory.publish_feedback));
   nh->declare_parameter(name + "." + "min_resolution_collision_check_angular", rclcpp::ParameterValue(trajectory.min_resolution_collision_check_angular));
@@ -200,6 +201,7 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "force_reinit_new_goal_angular", trajectory.force_reinit_new_goal_angular, trajectory.force_reinit_new_goal_angular);
   nh->get_parameter_or(name + "." + "feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
   nh->get_parameter_or(name + "." + "feasibility_check_slowdown_poses", trajectory.feasibility_check_slowdown_poses, trajectory.feasibility_check_slowdown_poses);
+  nh->get_parameter_or(name + "." + "feasibility_check_stop_poses", trajectory.feasibility_check_stop_poses, trajectory.feasibility_check_stop_poses);
   nh->get_parameter_or(name + "." + "feasibility_check", trajectory.feasibility_check, trajectory.feasibility_check);
   nh->get_parameter_or(name + "." + "publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
   nh->get_parameter_or(name + "." + "min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -442,7 +442,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
 
     if (unfeasible_pose > -1)
     {
-        RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);
+        RCLCPP_INFO(nh_->get_logger(), "Unfeasible pose is %d", unfeasible_pose);
       if (unfeasible_pose <= cfg_->trajectory.feasibility_check_stop_poses){
         cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
 
@@ -457,8 +457,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
             );
       }
       else{
-        max_velocity_x = max_velocity_x * (float)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (float)(cfg_->trajectory.feasibility_check_no_poses -  cfg_->trajectory.feasibility_check_stop_poses);
-      RCLCPP_INFO(nh_->get_logger(), "max vel pose is %f", max_velocity_x);
+        max_velocity_x = max_velocity_x * (double)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (double)(cfg_->trajectory.feasibility_check_no_poses -  cfg_->trajectory.feasibility_check_stop_poses);
       }
     }
   }

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -439,7 +439,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     unfeasible_pose = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
     if (unfeasible_pose > -1)
     {
-        RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose)
+        RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);
       if (unfeasible_pose <= cfg_->trajectory.feasibility_check_stop_poses){
         cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
 

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -434,9 +434,11 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     footprint_spec_ = costmap_ros_->getRobotFootprint();
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
-  int unfeasible_pose = -1;
+  int unfeasible_pose = -2;
   if (cfg_->trajectory.feasibility_check){
     unfeasible_pose = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
+    RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);
+
     if (unfeasible_pose > -1)
     {
         RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -447,6 +447,8 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     time_last_infeasible_plan_ = nh_->now();
     last_cmd_ = cmd_vel.twist;
     no_infeasible_slowdown_plans_++;
+    RCLCPP_INFO(nh_->get_logger(), "Nr. infeasible slowdown: %d", no_infeasible_slowdown_plans_);
+
     if (no_infeasible_slowdown_plans_ > 4){
         throw nav2_core::PlannerException(
           std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -426,7 +426,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
       std::string("teb_local_planner was not able to obtain a local plan for the current setting.")
     );
   }
-  double max_velocity_x = cfg_->robot.max_vel_x
+  double max_velocity_x = cfg_->robot.max_vel_x;
   // Check feasibility (but within the first few states only)
   if(cfg_->robot.is_footprint_dynamic)
   {
@@ -434,7 +434,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     footprint_spec_ = costmap_ros_->getRobotFootprint();
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
-  int unfeasible_pose = -1
+  int unfeasible_pose = -1;
   if (cfg_->trajectory.feasibility_check){
     unfeasible_pose = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
     if (!(unfeasible_pose > -1))
@@ -446,14 +446,14 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
         planner_->clearPlanner();
 
         ++no_infeasible_plans_; // increase number of infeasible solutions in a row
-        time_last_infeasible_plan_ = clock_->now();
+        time_last_infeasible_plan_ = clock->now();
         last_cmd_ = cmd_vel.twist;
         throw nav2_core::PlannerException(
               std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
             );
       }
       else if (unfeasible_pose < cfg_->trajectory.feasibility_check_slowdown_poses){
-        max_velocity_x = max_velocity_x / (cfg_->trajectory.feasibility_check_slowdown_poses - unfeasible_pose)
+        max_velocity_x = max_velocity_x / (cfg_->trajectory.feasibility_check_slowdown_poses - unfeasible_pose);
       }
     }
     else if (unfeasible_pose == -2) {
@@ -1200,13 +1200,13 @@ void TebLocalPlannerROS::configureBackupModes(std::vector<geometry_msgs::msg::Po
     if (cfg_->recovery.oscillation_recovery)
     {
         double max_vel_theta;
-        double max_vel_current = last_cmd_.linear.x >= 0 ? max_velocity_x : cfg_->robot.max_vel_x_backwards;
+        double max_vel_current = last_cmd_.linear.x >= 0 ? cfg_->robot.max_vel_x : cfg_->robot.max_vel_x_backwards;
         if (cfg_->robot.min_turning_radius!=0 && max_vel_current>0)
             max_vel_theta = std::max( max_vel_current/std::abs(cfg_->robot.min_turning_radius),  cfg_->robot.max_vel_theta );
         else
             max_vel_theta = cfg_->robot.max_vel_theta;
         
-        failure_detector_.update(last_cmd_, max_velocity_x, cfg_->robot.max_vel_x_backwards, max_vel_theta,
+        failure_detector_.update(last_cmd_, cfg_->robot.max_vel_x, cfg_->robot.max_vel_x_backwards, max_vel_theta,
                                cfg_->recovery.oscillation_v_eps, cfg_->recovery.oscillation_omega_eps);
         
         bool oscillating = failure_detector_.isOscillating();

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -457,7 +457,8 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
             );
       }
       else if (unfeasible_pose <= cfg_->trajectory.feasibility_check_slowdown_poses){
-        max_velocity_x = max_velocity_x * (unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (cfg_->trajectory.feasibility_check_slowdown_poses -  cfg_->trajectory.feasibility_check_stop_poses);
+        max_velocity_x = max_velocity_x * (float)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (float)(cfg_->trajectory.feasibility_check_slowdown_poses -  cfg_->trajectory.feasibility_check_stop_poses);
+      RCLCPP_INFO(nh_->get_logger(), "max vel pose is %f", max_velocity_x);
       }
     }
   }

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -446,7 +446,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
         planner_->clearPlanner();
 
         ++no_infeasible_plans_; // increase number of infeasible solutions in a row
-        time_last_infeasible_plan_ = clock->now();
+        time_last_infeasible_plan_ = nh_->now();
         last_cmd_ = cmd_vel.twist;
         throw nav2_core::PlannerException(
               std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -449,7 +449,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     no_infeasible_slowdown_plans_++;
     RCLCPP_INFO(nh_->get_logger(), "Nr. infeasible slowdown: %d", no_infeasible_slowdown_plans_);
 
-    if (no_infeasible_slowdown_plans_ > 4){
+    if (no_infeasible_slowdown_plans_ >  cfg_->trajectory.feasibility_check_slowdown_poses){
         throw nav2_core::PlannerException(
           std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
         );

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -513,9 +513,9 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     time_last_published_global_plan_ = nh_->now().seconds();
   }
   if (no_infeasible_slowdown_plans_ > 0){
-    cmd_vel.twist.linear.x = cmd_vel.twist.linear.x / (no_infeasible_slowdown_plans_ + 1.0)
-    cmd_vel.twist.linear.y = cmd_vel.twist.linear.y / (no_infeasible_slowdown_plans_ + 1.0)
-    cmd_vel.twist.angular.z = cmd_vel.twist.angular.z / (no_infeasible_slowdown_plans_ + 1.0)
+    cmd_vel.twist.linear.x = cmd_vel.twist.linear.x / (no_infeasible_slowdown_plans_ + 1.0);
+    cmd_vel.twist.linear.y = cmd_vel.twist.linear.y / (no_infeasible_slowdown_plans_ + 1.0);
+    cmd_vel.twist.angular.z = cmd_vel.twist.angular.z / (no_infeasible_slowdown_plans_ + 1.0);
   }
   return cmd_vel;
 }

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -461,8 +461,6 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
 
   if (no_infeasible_slowdown_plans_ > 0){
     cmd_vel.twist.linear.x = cmd_vel.twist.linear.x / (no_infeasible_slowdown_plans_ + 1.0);
-    cmd_vel.twist.linear.y = cmd_vel.twist.linear.y / (no_infeasible_slowdown_plans_ + 1.0);
-    cmd_vel.twist.angular.z = cmd_vel.twist.angular.z / (no_infeasible_slowdown_plans_ + 1.0);
   }
 
   // Get the velocity command for this sampling interval

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -435,6 +435,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
   int unfeasible_pose = -2;
+  RCLCPP_INFO(nh_->get_logger(), " pose is %d, feas check: %d", unfeasible_pose, cfg_->trajectory.feasibility_check);
   if (cfg_->trajectory.feasibility_check){
     unfeasible_pose = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
     RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -456,8 +456,8 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
               std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
             );
       }
-      else if (unfeasible_pose <= cfg_->trajectory.feasibility_check_slowdown_poses){
-        max_velocity_x = max_velocity_x * (float)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (float)(cfg_->trajectory.feasibility_check_slowdown_poses -  cfg_->trajectory.feasibility_check_stop_poses);
+      else{
+        max_velocity_x = max_velocity_x * (float)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (float)(cfg_->trajectory.feasibility_check_no_poses -  cfg_->trajectory.feasibility_check_stop_poses);
       RCLCPP_INFO(nh_->get_logger(), "max vel pose is %f", max_velocity_x);
       }
     }

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -435,14 +435,12 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     nav2_costmap_2d::calculateMinAndMaxDistances(footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius);
   }
   int unfeasible_pose = -2;
-  RCLCPP_INFO(nh_->get_logger(), " pose is %d, feas check: %d", unfeasible_pose, cfg_->trajectory.feasibility_check);
   if (cfg_->trajectory.feasibility_check){
     unfeasible_pose = planner_->isTrajectoryFeasible(costmap_model_.get(), footprint_spec_, robot_inscribed_radius_, robot_circumscribed_radius, cfg_->trajectory.feasibility_check_no_poses);
-    RCLCPP_INFO(nh_->get_logger(), "Unfesible pose is %d", unfeasible_pose);
 
     if (unfeasible_pose > -1)
     {
-        RCLCPP_INFO(nh_->get_logger(), "Unfeasible pose is %d", unfeasible_pose);
+      RCLCPP_INFO(nh_->get_logger(), "Pose is unfeasible, index is %d", unfeasible_pose);
       if (unfeasible_pose <= cfg_->trajectory.feasibility_check_stop_poses){
         cmd_vel.twist.linear.x = cmd_vel.twist.linear.y = cmd_vel.twist.angular.z = 0;
 
@@ -456,7 +454,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
               std::string("TebLocalPlannerROS: trajectory is not feasible. Resetting planner...")
             );
       }
-      else{
+      else {
         max_velocity_x = max_velocity_x * (double)(unfeasible_pose - cfg_->trajectory.feasibility_check_stop_poses) / (double)(cfg_->trajectory.feasibility_check_no_poses -  cfg_->trajectory.feasibility_check_stop_poses);
       }
     }
@@ -515,7 +513,6 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     visualization_->publishGlobalPlan(global_plan_);
     time_last_published_global_plan_ = nh_->now().seconds();
   }
-
   return cmd_vel;
 }
 

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -459,6 +459,12 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     no_infeasible_slowdown_plans_ = 0;
   }
 
+  if (no_infeasible_slowdown_plans_ > 0){
+    cmd_vel.twist.linear.x = cmd_vel.twist.linear.x / (no_infeasible_slowdown_plans_ + 1.0);
+    cmd_vel.twist.linear.y = cmd_vel.twist.linear.y / (no_infeasible_slowdown_plans_ + 1.0);
+    cmd_vel.twist.angular.z = cmd_vel.twist.angular.z / (no_infeasible_slowdown_plans_ + 1.0);
+  }
+
   // Get the velocity command for this sampling interval
   if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z, cfg_->trajectory.control_look_ahead_poses))
   {
@@ -512,11 +518,7 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
     visualization_->publishGlobalPlan(global_plan_);
     time_last_published_global_plan_ = nh_->now().seconds();
   }
-  if (no_infeasible_slowdown_plans_ > 0){
-    cmd_vel.twist.linear.x = cmd_vel.twist.linear.x / (no_infeasible_slowdown_plans_ + 1.0);
-    cmd_vel.twist.linear.y = cmd_vel.twist.linear.y / (no_infeasible_slowdown_plans_ + 1.0);
-    cmd_vel.twist.angular.z = cmd_vel.twist.angular.z / (no_infeasible_slowdown_plans_ + 1.0);
-  }
+
   return cmd_vel;
 }
 


### PR DESCRIPTION
Enable the feasibility check in TEB, that slows down / stops the vehicle if one of the next poses is not feasible.

In the original TEB implementation, if a trajectory is found to be infeasible, it will be removed from the homotopy classes, so that in the next iteration, other trajectories will be considered. As we only want to slow down for obstacles first, removing them seemed troublesome in my testing, as then the AMR oscillated between different other trajectories. It seems better to just keep the trajectories, and wait for them to become obstacle-free again - or fail the navigation.

In the future, in case we also add a costmap converter to add local costmap obstacles as TEB obstacles, we might want to bring back the original logic.

I've tested this for a while in the basement, it doesn't seem to cause any issues anymore. In any case, if feasibility_check is set to False, this logic will not be use at all anymore.

Most of the work here was done by @rdeniza , I just finished this up while he's busy with his thesis