### PR TITLE
Galactic custom obstacles topics

### DIFF
--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -61,6 +61,8 @@ public:
   using UniquePtr = std::unique_ptr<TebConfig>;
   
   std::string odom_topic; //!< Topic name of the odometry message, provided by the robot driver or simulator
+  std::string custom_obst_topic; //!< Topic name of the custom obstacle message, provided by the robot driver or simulator
+  std::string custom_narrow_obst_topic; //!< Topic name of the custom narrow obstacles message,  obstacles are provided by the AdjustPalletGoal Action Server
   std::string map_frame; //!< Global planning frame
   std::string node_name; //!< node name used for parameter event callback
 
@@ -240,6 +242,8 @@ public:
   {
 
     odom_topic = "odom";
+    custom_obst_topic = "obstacles";
+    custom_narrow_obst_topic = "narrow_obstacles";
     map_frame = "odom";
 
     // Trajectory

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -387,8 +387,12 @@ private:
 
   //std::shared_ptr< dynamic_reconfigure::Server<TebLocalPlannerReconfigureConfig> > dynamic_recfg_; //!< Dynamic reconfigure server to allow config modifications at runtime
   rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
+  rclcpp::Subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>::SharedPtr custom_narrow_obst_sub_; //!< Subscriber for custom narrow obstacles received via a ObstacleMsg.
   std::mutex custom_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
+  std::mutex custom_narrow_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   costmap_converter_msgs::msg::ObstacleArrayMsg custom_obstacle_msg_; //!< Copy of the most recent obstacle message
+
+  costmap_converter_msgs::msg::ObstacleArrayMsg custom_narrow_obstacle_msg_; //!< Copy of the most recent obstacle message
 
   rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr via_points_sub_; //!< Subscriber for custom via-points received via a Path msg.
   bool custom_via_points_active_; //!< Keep track whether valid via-points have been received from via_points_sub_

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -239,7 +239,16 @@ protected:
     * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
     */
   void customObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
-  
+
+
+    /**
+     * @brief Callback for custom narrow aisle obstacles that are not obtained from the costmap.
+     * Adjust Pallet Goal Action server provides this obstacles
+     * @param obst_msg pointer to the message containing a list of polygon shaped obstacles
+     */
+    void customNarrowObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg);
+
+
    /**
     * @brief Callback for custom via-points
     * @param via_points_msg pointer to the message containing a list of via-points

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -47,6 +47,8 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   node_name = name;
 
   declare_parameter_if_not_declared(nh, name + "." + "odom_topic", rclcpp::ParameterValue(odom_topic));
+  declare_parameter_if_not_declared(nh, name + "." + "custom_obst_topic", rclcpp::ParameterValue(custom_obst_topic));
+  declare_parameter_if_not_declared(nh, name + "." + "custom_narrow_obst_topic", rclcpp::ParameterValue(custom_narrow_obst_topic));
   declare_parameter_if_not_declared(nh, name + "." + "map_frame", rclcpp::ParameterValue(map_frame));
 
   // Trajectory
@@ -172,6 +174,8 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
 void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::SharedPtr nh, const std::string name)
 {
   nh->get_parameter_or(name + "." + "odom_topic", odom_topic, odom_topic);
+  nh->get_parameter_or(name + "." + "custom_obst_topic", custom_obst_topic, custom_obst_topic);
+  nh->get_parameter_or(name + "." + "custom_narrow_obst_topic", custom_narrow_obst_topic, custom_narrow_obst_topic);
   nh->get_parameter_or(name + "." + "map_frame", map_frame, map_frame);
   
   // Trajectory

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -172,9 +172,15 @@ void TebLocalPlannerROS::initialize(nav2_util::LifecycleNode::SharedPtr node)
         
     // setup callback for custom obstacles
     custom_obst_sub_ = node->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
-                "obstacles", 
+                cfg_->custom_obst_topic,
                 rclcpp::SystemDefaultsQoS(),
                 std::bind(&TebLocalPlannerROS::customObstacleCB, this, std::placeholders::_1));
+
+     // setup callback for custom narrow aisle obstacles
+      custom_narrow_obst_sub_ = node->create_subscription<costmap_converter_msgs::msg::ObstacleArrayMsg>(
+              cfg_->custom_narrow_obst_topic,
+              rclcpp::SystemDefaultsQoS(),
+              std::bind(&TebLocalPlannerROS::customNarrowObstacleCB, this, std::placeholders::_1));
 
     // setup callback for custom via-points
     via_points_sub_ = node->create_subscription<nav_msgs::msg::Path>(
@@ -551,6 +557,8 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
   // Add custom obstacles obtained via message
   std::lock_guard<std::mutex> l(custom_obst_mutex_);
 
+  std::lock_guard<std::mutex> l2(custom_narrow_obst_mutex_);
+
   if (!custom_obstacle_msg_.obstacles.empty())
   {
     // We only use the global header to specify the obstacle coordinate system instead of individual ones
@@ -619,6 +627,77 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
       // Set velocity, if obstacle is moving
       if(!obstacles_.empty())
         obstacles_.back()->setCentroidVelocity(custom_obstacle_msg_.obstacles[i].velocities, custom_obstacle_msg_.obstacles[i].orientation);
+    }
+  }
+  // ADD Narrow isle obstacles
+  if (!custom_narrow_obstacle_msg_.obstacles.empty())
+  {
+    // We only use the global header to specify the obstacle coordinate system instead of individual ones
+    Eigen::Affine3d obstacle_to_map_eig;
+    try
+    {
+      geometry_msgs::msg::TransformStamped obstacle_to_map = tf_->lookupTransform(
+                  global_frame_, tf2::timeFromSec(0),
+                  custom_narrow_obstacle_msg_.header.frame_id, tf2::timeFromSec(0),
+                  custom_narrow_obstacle_msg_.header.frame_id, tf2::durationFromSec(0.5));
+      obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
+      //tf2::fromMsg(obstacle_to_map.transform, obstacle_to_map_eig);
+    }
+    catch (tf2::TransformException ex)
+    {
+      RCLCPP_ERROR(logger_, "%s",ex.what());
+      obstacle_to_map_eig.setIdentity();
+    }
+
+    for (size_t i=0; i<custom_narrow_obstacle_msg_.obstacles.size(); ++i)
+    {
+      if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 && custom_narrow_obstacle_msg_.obstacles.at(i).radius > 0 ) // circle
+      {
+        Eigen::Vector3d pos( custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z );
+        obstacles_.push_back(ObstaclePtr(new CircularObstacle( (obstacle_to_map_eig * pos).head(2), custom_narrow_obstacle_msg_.obstacles.at(i).radius)));
+      }
+      else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 1 ) // point
+      {
+        Eigen::Vector3d pos( custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                             custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z );
+        obstacles_.push_back(ObstaclePtr(new PointObstacle( (obstacle_to_map_eig * pos).head(2) )));
+      }
+      else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size() == 2 ) // line
+      {
+        Eigen::Vector3d line_start( custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().x,
+                                    custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().y,
+                                    custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.front().z );
+        Eigen::Vector3d line_end( custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().x,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().y,
+                                  custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.back().z );
+        obstacles_.push_back(ObstaclePtr(new LineObstacle( (obstacle_to_map_eig * line_start).head(2),
+                                                           (obstacle_to_map_eig * line_end).head(2) )));
+      }
+      else if (custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.empty())
+      {
+        RCLCPP_INFO(logger_, "Invalid custom narrow obstacle received. List of polygon vertices is empty. Skipping...");
+        continue;
+      }
+      else // polygon
+      {
+        PolygonObstacle* polyobst = new PolygonObstacle;
+        for (size_t j=0; j<custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points.size(); ++j)
+        {
+          Eigen::Vector3d pos( custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].x,
+                               custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].y,
+                               custom_narrow_obstacle_msg_.obstacles.at(i).polygon.points[j].z );
+          polyobst->pushBackVertex( (obstacle_to_map_eig * pos).head(2) );
+        }
+        polyobst->finalizePolygon();
+        obstacles_.push_back(ObstaclePtr(polyobst));
+      }
+
+      // Set velocity, if obstacle is moving
+      if(!obstacles_.empty())
+        obstacles_.back()->setCentroidVelocity(custom_narrow_obstacle_msg_.obstacles[i].velocities, custom_narrow_obstacle_msg_.obstacles[i].orientation);
     }
   }
 }
@@ -1085,6 +1164,12 @@ void TebLocalPlannerROS::customObstacleCB(const costmap_converter_msgs::msg::Obs
 {
   std::lock_guard<std::mutex> l(custom_obst_mutex_);
   custom_obstacle_msg_ = *obst_msg;  
+}
+
+void TebLocalPlannerROS::customNarrowObstacleCB(const costmap_converter_msgs::msg::ObstacleArrayMsg::ConstSharedPtr obst_msg)
+{
+    std::lock_guard<std::mutex> l2(custom_narrow_obst_mutex_);
+    custom_narrow_obstacle_msg_ = *obst_msg;
 }
 
 void TebLocalPlannerROS::customViaPointsCB(const nav_msgs::msg::Path::ConstSharedPtr via_points_msg)


### PR DESCRIPTION
Taken from our foxy branch. Adds a parameter for the "obstacles" topic name, and a second, similar topic for a second set of obstacles.
We have multiple nodes publishing obstacles independently, within different frames, so to avoid this change here we'd need an explicit obstacle merging node, which would be considerable overhead.

