### PR TITLE
remove nav2_bringup as dependency

### DIFF
--- a/teb_local_planner/package.xml
+++ b/teb_local_planner/package.xml
@@ -42,7 +42,6 @@
   <depend>tf2_eigen</depend>
   <depend>visualization_msgs</depend>
   <depend>builtin_interfaces</depend>
-  <exec_depend>nav2_bringup</exec_depend>
   
   <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
This causes to build all the packages in nav2 althought teb needs only few