### PR TITLE
AMRNAV-4849 set speed_limit

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -1085,19 +1085,10 @@ void TebLocalPlannerROS::setSpeedLimit(const double& speed_limit,
         // as absolute linear speed changed in order to preserve
         // robot moving trajectories to be the same after speed change.
         // G. Doisy: not sure if that's applicable to base_max_vel_x_backwards.
-        const double ratio = speed_limit / max_speed_xy;
-        cfg_->robot.max_vel_x = cfg_->robot.base_max_vel_x * ratio;
-        cfg_->robot.max_vel_x_backwards =
-            cfg_->robot.base_max_vel_x_backwards * ratio;
-        cfg_->robot.max_vel_y = cfg_->robot.base_max_vel_y * ratio;
-        cfg_->robot.max_vel_theta = cfg_->robot.base_max_vel_theta * ratio;
-
+        cfg_->robot.max_vel_x = speed_limit;
       } else {
         // Restore defaults
         cfg_->robot.max_vel_x = cfg_->robot.base_max_vel_x;
-        cfg_->robot.max_vel_x_backwards = cfg_->robot.base_max_vel_x_backwards;
-        cfg_->robot.max_vel_y = cfg_->robot.base_max_vel_y;
-        cfg_->robot.max_vel_theta = cfg_->robot.base_max_vel_theta;
       }
     }
   }


### PR DESCRIPTION
When setting a speed limit in navigation, in TEB, it is applied proportionally to the angular velocity as well. The idea is "to preserve robot moving trajectories to be the same after speed change."
( /code/ros2_ws/src/teb_local_planner/teb_local_planner/src/teb_local_planner_ros.cpp )

However, this is not actually the case, as TEB doesn't always saturate both limits. E.g. if TEB simply wants to turn, it could output
vel_x = 0.3
vel_theta = 0.3

Now, if max_vel_x = 1.5, and max_vel_theta = 0.3, and speed_limit = 0.3, TEB would set the speed_limit_theta = 0.06

So, the output command would be
vel_x = 0.3
vel_theta = 0.06

Which, in fact, changes the intended command by a lot.

For now, let's simply remove the setting of a theta speed limit, when a linear speed limit is set.
