### PR TITLE
AMRNAV-4908 Fix speed limit for driving backwards

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -1086,9 +1086,11 @@ void TebLocalPlannerROS::setSpeedLimit(const double& speed_limit,
         // robot moving trajectories to be the same after speed change.
         // G. Doisy: not sure if that's applicable to base_max_vel_x_backwards.
         cfg_->robot.max_vel_x = speed_limit;
+        cfg_->robot.max_vel_x_backwards = speed_limit;
       } else {
         // Restore defaults
         cfg_->robot.max_vel_x = cfg_->robot.base_max_vel_x;
+        cfg_->robot.max_vel_x_backwards = cfg_->robot.base_max_vel_x_backwards;
       }
     }
   }


### PR DESCRIPTION
Ticket: https://lvserv01.logivations.com/browse/AMRNAV-4908
In https://github.com/logivations/teb_local_planner/pull/40 the backwards speed limit was removed i assume by accident.
We use the speed limit for driving backwards when we do pallet pickup not to bump into pallet

Before:
![Screenshot from 2023-06-14 13-35-21](https://github.com/logivations/teb_local_planner/assets/87417416/0e9f36ef-bb1c-497b-8c05-971c51f3ebc6)

---
After: 
![Screenshot from 2023-06-14 13-42-37](https://github.com/logivations/teb_local_planner/assets/87417416/b3a215a0-16c5-4424-a027-60a55458023b)
