### PR TITLE
Remove global plan publishing

### DIFF
--- a/teb_local_planner/include/teb_local_planner/visualization.h
+++ b/teb_local_planner/include/teb_local_planner/visualization.h
@@ -91,13 +91,7 @@ public:
   
   /** @name Publish to topics */
   //@{
-  
-  /**
-   * @brief Publish a given global plan to the ros topic \e ../../global_plan
-   * @param global_plan Pose array describing the global plan
-   */
-  void publishGlobalPlan(const std::vector<geometry_msgs::msg::PoseStamped>& global_plan) const;
-  
+
   /**
    * @brief Publish a given local plan to the ros topic \e ../../local_plan
    * @param local_plan Pose array describing the local plan

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -465,7 +465,6 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(con
   planner_->visualize();
   visualization_->publishObstacles(obstacles_);
   visualization_->publishViaPoints(via_points_);
-  visualization_->publishGlobalPlan(global_plan_);
 
   return cmd_vel;
 }

--- a/teb_local_planner/src/visualization.cpp
+++ b/teb_local_planner/src/visualization.cpp
@@ -529,7 +529,6 @@ nav2_util::CallbackReturn TebVisualization::on_configure()
 nav2_util::CallbackReturn 
 TebVisualization::on_activate()
 {
-  global_plan_pub_->on_activate();
   local_plan_pub_->on_activate();
   teb_poses_pub_->on_activate();
   teb_marker_pub_->on_activate();
@@ -541,7 +540,6 @@ TebVisualization::on_activate()
 nav2_util::CallbackReturn 
 TebVisualization::on_deactivate()
 {
-  global_plan_pub_->on_deactivate();
   local_plan_pub_->on_deactivate();
   teb_poses_pub_->on_deactivate();
   teb_marker_pub_->on_deactivate();
@@ -553,7 +551,6 @@ TebVisualization::on_deactivate()
 nav2_util::CallbackReturn 
 TebVisualization::on_cleanup()
 {
-  global_plan_pub_.reset();
   local_plan_pub_.reset();
   teb_poses_pub_.reset();
   teb_marker_pub_.reset();

--- a/teb_local_planner/src/visualization.cpp
+++ b/teb_local_planner/src/visualization.cpp
@@ -65,12 +65,6 @@ TebVisualization::TebVisualization(const rclcpp_lifecycle::LifecycleNode::Shared
 {
 }
 
-void TebVisualization::publishGlobalPlan(const std::vector<geometry_msgs::msg::PoseStamped>& global_plan) const
-{
-  if ( printErrorWhenNotInitialized() )
-    return;
-  publishPlan(global_plan, global_plan_pub_.get());
-}
 
 void TebVisualization::publishLocalPlan(const std::vector<geometry_msgs::msg::PoseStamped>& local_plan) const
 {
@@ -522,7 +516,6 @@ bool TebVisualization::printErrorWhenNotInitialized() const
 nav2_util::CallbackReturn TebVisualization::on_configure()
 {
   // register topics
-  global_plan_pub_ = nh_->create_publisher<nav_msgs::msg::Path>("global_plan", 1);;
   local_plan_pub_ = nh_->create_publisher<nav_msgs::msg::Path>("local_plan",1);
   teb_poses_pub_ = nh_->create_publisher<geometry_msgs::msg::PoseArray>("teb_poses", 1);
   teb_marker_pub_ = nh_->create_publisher<visualization_msgs::msg::Marker>("teb_markers", 1);


### PR DESCRIPTION
We now publish to /global_plan from controller_server and to avoid duplication we should remove publishing global_plan in teb:
https://github.com/logivations/deep_cv/pull/10064